### PR TITLE
Single Charge Bases + DiagDevice

### DIFF
--- a/qcsys/devices/base.py
+++ b/qcsys/devices/base.py
@@ -19,7 +19,9 @@ config.update("jax_enable_x64", True)
 class BasisTypes(str, Enum):
     fock = "fock"
     charge = "charge"
-    single_charge = "single_charge"
+    singlecharge = "single_charge"
+    singlecharge_even = "singlecharge_even"
+    singlecharge_odd = "singlecharge_odd"
 
     @classmethod
     def from_str(cls, string: str):
@@ -340,4 +342,37 @@ class FluxDevice(Device):
         fig.tight_layout()
 
         return ax
+    
 
+@struct.dataclass
+class DiagDevice(ABC):
+    N: int = struct.field(pytree_node=False)
+    N_pre_diag: int = struct.field(pytree_node=False)
+    params: Dict[str, Any]
+    init_ops: Dict[str, Any] = struct.field(pytree_node=False)
+    init_evals: Array = struct.field(pytree_node=False)
+
+    @classmethod
+    def create(cls, N, N_pre_diag, params, ops, evals):
+        """Create a device.
+
+        Args:
+            N (int): dimension of Hilbert space.
+            params (dict): parameters of the device.
+        """
+        assert N_pre_diag >= N, "N_pre_diag must be greater than or equal to N."
+
+        return cls(N, N_pre_diag, params, ops, evals)
+
+    def process_ops_diag(self, ops):
+        ops_trunc = {}
+        for name, op in ops.items():
+            ops_trunc[name] = jqt.jnp2jqt(op.data[:self.N, :self.N])
+        return ops_trunc
+    
+    @property
+    def ops(self):
+        return self.process_ops_diag(self.init_ops)
+    
+    def get_H(self):
+        return jqt.jnp2jqt(jnp.diag(self.init_evals[:self.N]))


### PR DESCRIPTION
Adding some small fixes to the single charge basis of the transmon - in particular, we now have three separate single charge bases (full, even, odd). With this, I think the single-charge basis is fully fleshed out.

---

Also added a `DiagDevice`. The whole point of `qcsys` is to pipeline diagonalizations via nested functions (i.e. JAX style). However, this means that any time we diagonalize a `System`, we are also diagonalizing each subsystem first. That is, simply calling `qubit.get_H()` involves diagonalizing a `N_pre_diag`-dimensional matrix. If `N_pre_diag` for each subsystem is large (e.g. >1000), then this gets very slow when working with systems. 

My proposed solution is to diagonalize each subsystem _once_ and save the resulting (truncated) eigenvalues to a file (e.g. npz). Then, we can create a new `DiagDevice`, whose Hamiltonian is diagonal and is already written in the energy eigenbasis. This class has a `get_H()` method, so it is compatible with other devices. This will speed up the construction of composite system Hamiltonians, since instead of having to rediagonalize each subsystem, we can just use the stored data. 

[The specific use case where this is highly advantageous is when we want to sweep the coupling between two fixed subsystems, e.g. `H_total = H_a + H_b + g_ab * H_int` where we sweep `g_ab`]